### PR TITLE
Changed journal location in examples to default, to avoid facing an erro...

### DIFF
--- a/examples/nodes/first.yaml
+++ b/examples/nodes/first.yaml
@@ -2,5 +2,5 @@
 ######## OSD
 ceph::profile::params::osds:
   '/dev/sdb':
-    journal: '/tmp/journal'
+    journal: 
 

--- a/examples/nodes/second.yaml
+++ b/examples/nodes/second.yaml
@@ -2,5 +2,5 @@
 ######## OSD
 ceph::profile::params::osds:
   '/dev/sdb':
-    journal: '/tmp/journal'
+    journal: 
 

--- a/manifests/osd.pp
+++ b/manifests/osd.pp
@@ -71,7 +71,8 @@ fi
         unless    => "/bin/true  # comment to satisfy puppet syntax requirements
 set -ex
 ceph-disk list | grep ' *${data}.*ceph data, active' ||
-ls -l /var/lib/ceph/osd/${cluster_name}-* | grep ' ${data}'
+ls -l /var/lib/ceph/osd/${cluster_name}-* | grep ' ${data}' ||
+ceph-disk list | grep ' *${data}.*mounted.*/ceph/osd/.*'
 ",
         logoutput => true,
       }


### PR DESCRIPTION
Changed journal location in examples to default, to avoid facing an error on osd start after node reboot ('journal not present, not starting yet.')

Setting the journal location to `/tmp/journal` is a bad idea because the folder is flushed after each reboot and the OSD will fail to start. It means that we'll must prepare a new OSD, activate it and destroy the previous one manually. It's not convenient for people with low understandings of Ceph or for people who just want to try puppet-ceph.

I advice changing the journal location to default, as it will write it by default to a file in `/var/lib/ceph/osd/<osd name>`.