### PR TITLE
use full length APT key

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -54,7 +54,7 @@ class ceph::repo (
 
       apt::key { 'ceph':
         ensure     => $ensure,
-        key        => '17ED316D',
+        key        => '7F6C9F236D170493FCF404F27EBFDD5D17ED316D',
         key_source => 'http://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc',
       }
 
@@ -81,7 +81,7 @@ class ceph::repo (
 
         apt::key { 'ceph-gitbuilder':
           ensure     => $ensure,
-          key        => '6EAEAE2203C3951A',
+          key        => 'FCC5CB2ED8E6F6FB79D5B3316EAEAE2203C3951A',
           key_server => 'keyserver.ubuntu.com',
         }
 


### PR DESCRIPTION
This is to make newer APT module versions happy. Without this change,
it always complains 'The id should be a full fingerprint (40 characters), see README.'