### PR TITLE
Added the option to set mon_clock_drift_allowed. Especially important…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,9 @@
 #   individually through ceph::mon.
 #   Optional. String like e.g. 'a, b, c'.
 #
+# [*mon_clock_drift_allowed*] The clock drift in seconds allowed between monitors.
+#   Optional. Float e.g. 0.10, 1. Default: 0.050
+#
 # [*require_signatures*] If Ceph requires signatures on all
 #   message traffic (client<->cluster and between cluster daemons).
 #   Optional. Boolean. Default provided by Ceph.
@@ -107,6 +110,7 @@ class ceph (
   $mon_osd_nearfull_ratio     = undef,
   $mon_initial_members        = undef,
   $mon_host                   = undef,
+  $mon_clock_drift_allowed    = undef,
   $require_signatures         = undef,
   $cluster_require_signatures = undef,
   $service_require_signatures = undef,
@@ -137,6 +141,7 @@ class ceph (
       'global/mon_osd_nearfull_ratio':      value => $mon_osd_nearfull_ratio;
       'global/mon_initial_members':         value => $mon_initial_members;
       'global/mon_host':                    value => $mon_host;
+      'global/mon_clock_drift_allowed':     value => $mon_clock_drift_allowed;
       'global/require_signatures':          value => $require_signatures;
       'global/cluster_require_signatures':  value => $cluster_require_signatures;
       'global/service_require_signatures':  value => $service_require_signatures;

--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -40,6 +40,7 @@ class ceph::profile::base {
     osd_pool_default_min_size => $ceph::profile::params::osd_pool_default_min_size,
     mon_initial_members       => $ceph::profile::params::mon_initial_members,
     mon_host                  => $ceph::profile::params::mon_host,
+    mon_clock_drift_allowed   => $ceph::profile::params::mon_clock_drift_allowed,
     cluster_network           => $ceph::profile::params::cluster_network,
     public_network            => $ceph::profile::params::public_network,
   }

--- a/manifests/profile/params.pp
+++ b/manifests/profile/params.pp
@@ -38,6 +38,9 @@
 #   individually through ceph::mon.
 #   Optional. String like e.g. 'a, b, c'.
 #
+# [*mon_clock_drift_allowed*] The clock drift in seconds allowed between monitors.
+#   Optional. Float e.g. 0.10, 1. Default: 0.050
+#
 # [*osd_journal_size*] The size of the journal file/device.
 #   Optional. Integer. Default provided by Ceph.
 #
@@ -98,6 +101,7 @@ class ceph::profile::params (
   $authentication_type = undef,
   $mon_initial_members = undef,
   $mon_host = undef,
+  $mon_clock_drift_allowed = undef,
   $osd_journal_size = undef,
   $osd_pool_default_pg_num = undef,
   $osd_pool_default_pgp_num = undef,


### PR DESCRIPTION
… for virtualized ceph monitors

Since I'm testing this module currently with virtual machines, I noticed that sometimes, even though we're using an ntp server, the cluster complains of "clock skew".

Thought it would be nice to add the option to increase the allowed threshold.