### PR TITLE
Update Ceph repository key

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -54,7 +54,7 @@ class ceph::repo (
 
       apt::key { 'ceph':
         ensure     => $ensure,
-        key        => '7F6C9F236D170493FCF404F27EBFDD5D17ED316D',
+        key        => '08B73419AC32B4E966C1A330E84AC2C0460F3994',
         key_source => 'http://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc',
       }
 

--- a/spec/classes/ceph_repo_spec.rb
+++ b/spec/classes/ceph_repo_spec.rb
@@ -33,7 +33,7 @@ describe 'ceph::repo' do
     describe "with default params" do
 
       it { is_expected.to contain_apt__key('ceph').with(
-        :key        => '7F6C9F236D170493FCF404F27EBFDD5D17ED316D',
+        :key        => '08B73419AC32B4E966C1A330E84AC2C0460F3994',
         :key_source => 'http://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc'
       ) }
 
@@ -74,7 +74,7 @@ describe 'ceph::repo' do
     describe "with default params" do
 
       it { is_expected.to contain_apt__key('ceph').with(
-        :key        => '7F6C9F236D170493FCF404F27EBFDD5D17ED316D',
+        :key        => '08B73419AC32B4E966C1A330E84AC2C0460F3994',
         :key_source => 'http://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc'
       ) }
 


### PR DESCRIPTION
https://ceph.com/releases/important-security-notice-regarding-signing-key-and-binary-downloads-of-ceph/